### PR TITLE
updated dockerfile to allow port to be dynamically set on build for r…

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,4 +9,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"]


### PR DESCRIPTION
This pull request makes a minor change to the `backend/Dockerfile` to improve flexibility when running the application in a Docker container.

- Updated the `CMD` instruction to allow the server port to be set via the `PORT` environment variable, defaulting to 8000 if not specified.…